### PR TITLE
Avoid goroutine leak

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    strategy:
+      # Don't abort the entire matrix if one element fails.
+      fail-fast: false
+      matrix:
+        gover: ["1.20.x", "1.21.x", "1.22.x"]
+        include:
+          - gover: "stable"
+            testflags: "-race"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.gover }}
+      - name: Test all
+        run: go test ${{ matrix.testflags }} ./...
+        env:
+          GOARCH: ${{ matrix.goarch }}
+  apidiff:
+    runs-on: ubuntu-22.04
+    if: (github.event.action && 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change'))
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+      - name: Run api-diff
+        uses: joelanford/go-apidiff@v0.8.2
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: stable
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          install-mode: "binary"

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/artefactual-labs/gearmin
 
-go 1.19
+go 1.20
 
 require (
+	github.com/google/go-cmp v0.5.9
 	github.com/mikespook/gearman-go v0.0.0-20220520031403-2a518e866145
+	go.uber.org/goleak v1.3.0
 	gotest.tools/v3 v3.5.1
 )
-
-require github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mikespook/gearman-go v0.0.0-20220520031403-2a518e866145 h1:6kTCi6p3Hd6JYROnq+1UOdewoXj90zKKDQPlsHYTSEs=
 github.com/mikespook/gearman-go v0.0.0-20220520031403-2a518e866145/go.mod h1:77Th6O6AZfMU6i5hLJnjN5xxUBoio7LN0aOyxGhqV1U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=

--- a/io.go
+++ b/io.go
@@ -20,9 +20,7 @@ func constructReply(tp packet, data [][]byte) []byte {
 	buf := &bytes.Buffer{}
 	buf.Write(resStr)
 
-	if err := binary.Write(buf, binary.BigEndian, tp.Uint32()); err != nil {
-		panic("should never happen")
-	}
+	_ = binary.Write(buf, binary.BigEndian, tp.Uint32())
 
 	length := 0
 	for i, arg := range data {
@@ -32,9 +30,7 @@ func constructReply(tp packet, data [][]byte) []byte {
 		}
 	}
 
-	if err := binary.Write(buf, binary.BigEndian, uint32(length)); err != nil {
-		panic("should never happen")
-	}
+	_ = binary.Write(buf, binary.BigEndian, uint32(length))
 
 	for i, arg := range data {
 		buf.Write(arg)
@@ -140,6 +136,7 @@ L:
 			}
 		}
 	}
+
 	// We throw away any messages waiting to be sent, including the
 	// nil message that is automatically sent when the in channel is closed
 	close(out)


### PR DESCRIPTION
This commit ensures that when the server is closing, we wait for all goroutines to stop, including those handling incoming connections.