### PR TITLE
Add high-load test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.gover }}
+      - name: Install gearman-tools
+        run: sudo apt install gearman-tools
       - name: Test all
         run: go test ${{ matrix.testflags }} ./...
         env:

--- a/protocol.go
+++ b/protocol.go
@@ -73,12 +73,12 @@ const (
 	//    RES    Client
 	packetGrabJobUniq //   REQ    Worker
 
-	packetJobAssignUniq   //   RES    Worker
+	packetJobAssignUniq   //  RES    Worker
 	packetSubmitJobHighBG //  REQ    Client
 	packetSubmitJobLow    //  REQ    Client
 	packetSubmitJobLowBG  //  REQ    Client
 	packetSubmitJobSched  //  REQ    Client
-	packetSubmitJobEpoch  //   36 REQ    Client
+	packetSubmitJobEpoch  //  REQ    Client
 
 	// New Codes (ref: https://github.com/gearman/gearmand/commit/eabf8a01030a16c80bada1e06c4162f8d129a5e8)
 	packetSubmitReduceJob           // REQ    Client
@@ -129,8 +129,12 @@ var labels = map[packet]string{
 	packetSubmitReduceJobBackground: "SUBMIT_REDUCE_JOB_BG",
 	packetGrabJobAll:                "GRAB_JOB_ALL",
 	packetJobAssignAll:              "JOB_ASSIGN_ALL",
-	packetGetStatusUnique:           "GET_STATUS_UNIQ",
-	packetStatusResUnique:           "STATUS_RES_UNIQ",
+	packetGetStatusUnique:           "GET_STATUS_UNIQUE",
+	packetStatusResUnique:           "STATUS_RES_UNIQUE",
+}
+
+func (i packet) String() string {
+	return i.label()
 }
 
 func (i packet) Uint32() uint32 {
@@ -142,11 +146,8 @@ func (i packet) label() string {
 }
 
 func newPacket(cmd uint32) (packet, error) {
-	if cmd >= packetCanDo.Uint32() && cmd <= packetSubmitJobEpoch.Uint32() {
+	if cmd >= packetCanDo.Uint32() && cmd <= packetStatusResUnique.Uint32() {
 		return packet(cmd), nil
-	}
-	if cmd >= packetSubmitReduceJob.Uint32() && cmd <= packetStatusResUnique.Uint32() {
-		return packet(cmd), fmt.Errorf("unsupported packet type %v", cmd)
 	}
 	return packet(cmd), fmt.Errorf("invalid packet type %v", cmd)
 }
@@ -189,6 +190,12 @@ var argc = []int{
 	/* SUBMIT_JOB_LOW_BG */ 3,
 	/* SUBMIT_JOB_SCHED */ 8,
 	/* SUBMIT_JOB_EPOCH */ 4,
+	/* SUBMIT_REDUCE_JOB */ 4,
+	/* SUBMIT_REDUCE_JOB_BG */ 4,
+	/* GRAB_JOB_ALL */ 0,
+	/* JOB_ASSIGN_ALL */ 5,
+	/* GET_STATUS_UNIQUE */ 1,
+	/* STATUS_RES_UNIQUE */ 1,
 }
 
 func (i packet) ArgCount() int {

--- a/server.go
+++ b/server.go
@@ -220,7 +220,7 @@ func (s *Server) processRequest(e *event) {
 	case packetSetClientId:
 		w := args.t0.(*worker)
 		w.id = args.t1.(string)
-	case packetGrabJobUniq:
+	case packetGrabJobUniq, packetGrabJobAll:
 		e.result <- s.handleGrabJobUniq(sessionID)
 	case packetPreSleep:
 		w := args.t0.(*worker)


### PR DESCRIPTION
I've disabled `TestWithGearmanGoWorker` because the worker package in `mikespook/gearman-go` is unreliable, but this PR shows with `TestHighLoadWithGearmanCLIWorker` that the same kind of load is manageable using the gearman CLI worker that is part of the gearman-tools package, just like I saw with the Python worker.

I've implemented `GRAB_JOB_ALL` and `JOB_ASSIGN_ALL` (without leveraging the reducer) for the `gearman -w` tool to work, but the server handles the same logic. Using three workers in parallel, 1k jobs are processed in ~0.30s.

```
$ go test -v -run=TestHighLoadWithGearmanCLIWorker -count=3
=== RUN   TestHighLoadWithGearmanCLIWorker
=== PAUSE TestHighLoadWithGearmanCLIWorker
=== CONT  TestHighLoadWithGearmanCLIWorker
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:45923)...
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:45923)...
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:45923)...
--- PASS: TestHighLoadWithGearmanCLIWorker (0.30s)
=== RUN   TestHighLoadWithGearmanCLIWorker
=== PAUSE TestHighLoadWithGearmanCLIWorker
=== CONT  TestHighLoadWithGearmanCLIWorker
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:45117)...
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:45117)...
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:45117)...
--- PASS: TestHighLoadWithGearmanCLIWorker (0.31s)
=== RUN   TestHighLoadWithGearmanCLIWorker
=== PAUSE TestHighLoadWithGearmanCLIWorker
=== CONT  TestHighLoadWithGearmanCLIWorker
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:36389)...
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:36389)...
    integration_test.go:146: Connecting gearman CLI worker to server ([::]:36389)...
--- PASS: TestHighLoadWithGearmanCLIWorker (0.30s)
PASS
ok  	github.com/artefactual-labs/gearmin	0.922s
```

Fixes issue #3.